### PR TITLE
0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 0.2.1
 
-- install `haproxy` with Ansible's `package` module instead of `apt`
+- install `haproxy` with Ansible's `package` module instead of `apt` (contribution by @szymon-filipiak)
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # CHANGELOG
 
+## 0.2.1
+
+- install `haproxy` with Ansible's `package` module instead of `apt`
+
 ## 0.2.0
 
 - introduce `haproxy_k8s_api_endpoint_port` variable


### PR DESCRIPTION
- install `haproxy` with Ansible's `package` module instead of `apt` (contribution by @szymon-filipiak)