### PR TITLE
0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.retry
+.ansible
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 <!--
-Copyright (C) 2023 Robert Wimmer
+Copyright (C) 2023-2026 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 # CHANGELOG
+
+## 0.2.2
+
+- replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
+- `tasks/main.yml`: fix forbidden implicit octal values
+- `meta/main.yml`: fix ansible-lint issue: Tags must contain lowercase letters and digits only., invalid: ha-proxy
+- add `.gitignore`
 
 ## 0.2.1
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,5 +17,4 @@ galaxy_info:
     - networking
     - linux
     - loadbalancer
-    - ha-proxy
     - haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2023 Robert Wimmer
+# Copyright (C) 2023-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Install haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: /etc/systemd/system/haproxy.service.d
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
 
@@ -22,7 +22,7 @@
     dest: /etc/systemd/system/haproxy.service.d/override.conf
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Reload systemd
     - Restart haproxy
@@ -33,7 +33,7 @@
     dest: /etc/haproxy/k8s_api_endpoint.cfg
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify:
     - Reload haproxy
 

--- a/templates/etc/haproxy/k8s_api_endpoint.cfg.j2
+++ b/templates/etc/haproxy/k8s_api_endpoint.cfg.j2
@@ -11,5 +11,5 @@ backend k8s_api_endpoint_backend
   stick on src
 
 {% for host in groups["k8s_controller"] %}
-  server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['ansible_' + k8s_interface].ipv4.address }}:{{ haproxy_k8s_api_endpoint_port }} check check-ssl verify none
+  server {{ hostvars[host]['ansible_facts']['hostname'] }} {{ hostvars[host]['ansible_facts'][k8s_interface]['ipv4']['address'] }}:{{ haproxy_k8s_api_endpoint_port }} check check-ssl verify none
 {% endfor %}


### PR DESCRIPTION
- replace injected `ansible_*` facts usage with `ansible_facts[...]` (prepares for ansible-core 2.24 where `INJECT_FACTS_AS_VARS` default changes)
- `tasks/main.yml`: fix forbidden implicit octal values
- `meta/main.yml`: fix ansible-lint issue: Tags must contain lowercase letters and digits only., invalid: ha-proxy
- add `.gitignore`